### PR TITLE
Update IOpenVPNAPIService.aidl

### DIFF
--- a/vpnLib/src/main/aidl/de/blinkt/openvpn/api/IOpenVPNAPIService.aidl
+++ b/vpnLib/src/main/aidl/de/blinkt/openvpn/api/IOpenVPNAPIService.aidl
@@ -63,4 +63,8 @@ interface IOpenVPNAPIService {
 
     /** Use a profile with all certificates etc. embedded */
     APIVpnProfile addNewVPNProfile (String name, boolean userEditable, String config);
+    
+    /** Same as startVPN(String), but also takes a Bundle with extra parameters,
+    * which will be applied to the created VPNProfile (e.g. allow vpn bypass). */
+    void startVPNwithExtras(in String inlineconfig, in Bundle extras);
 }


### PR DESCRIPTION
Ability to pass extras when starting VPN via AIDL using inline config.
To preserve backward compatibility, a new method is created: IOpenVPNAPIService#startVPNwithExtras(String, Bundle).
Currently only one parameter is supported:
de.blinkt.openvpn.api.ALLOW_VPN_BYPASS – boolean.