### PR TITLE
Update ExternalCertificateProvider.aidl

### DIFF
--- a/vpnLib/src/main/aidl/de/blinkt/openvpn/api/ExternalCertificateProvider.aidl
+++ b/vpnLib/src/main/aidl/de/blinkt/openvpn/api/ExternalCertificateProvider.aidl
@@ -36,4 +36,21 @@ interface ExternalCertificateProvider {
      *
      */
     Bundle getCertificateMetaData(in String alias);
+
+    /**
+     * Requests signing the data with RSA/ECB/PKCS1PADDING or RSA/ECB/nopadding
+     * for RSA certficate and with NONEwithECDSA for EC certificates
+     * @param alias user certificate identifier
+     * @param data the data to be signed
+     * @param extra additional information.
+     * Should contain the following keys:
+     * <p><ul>
+       * <li>int key "de.blinkt.openvpn.api.RSA_PADDING_TYPE", may be set as:
+       * <p><ul>
+         * <li>0 - for RSA/ECB/nopadding
+         * <li>1 - for RSA/ECB/PKCS1PADDING
+         * </ul><p>
+       * </ul><p>
+     */
+    byte[] getSignedDataWithExtra(in String alias, in byte[] data, in Bundle extra);
 }


### PR DESCRIPTION
Provide a padding type for externalCertificateProvider
Based on server-side OpenSSL behaviour the data to be signed by
externalCertificateProvider may be or may be not padded already.
To choose the proper signing mechanism we need to pass external info.